### PR TITLE
fix(designer): fix plugin-manager dispose method.

### DIFF
--- a/packages/designer/src/plugin/plugin-manager.ts
+++ b/packages/designer/src/plugin/plugin-manager.ts
@@ -253,5 +253,7 @@ export class LowCodePluginManager implements ILowCodePluginManager {
     await this.destroy();
     this.plugins = [];
     this.pluginsMap.clear();
+    this.pluginContextMap.clear();
+    this.pluginPreference?.clear();
   }
 }


### PR DESCRIPTION
In the packages/designer/src/plugin/plugin-manager.ts's method dispose,
the pluginContextMap and pluginPreference were not cleared.

Therefore, I'm submitting a Pull Request (PR) to fix this issue.